### PR TITLE
fix: accept new signed download URLs (Fileditch)

### DIFF
--- a/cyberdrop_dl/crawlers/fileditch.py
+++ b/cyberdrop_dl/crawlers/fileditch.py
@@ -154,6 +154,6 @@ def _extract_dl_url(soup: bs4.BeautifulSoup) -> AbsoluteHttpURL:
 def _parse_url_parts(js_array: str) -> AbsoluteHttpURL:
     parts: list[str] = json.loads(js_array)
     url = parse_url("".join(parts), trim=False)
-    if not (url.query.get("md5") and url.query.get("expires")):
+    if not ((url.query.get("md5") and url.query.get("expires")) or (url.query.get("exp") and url.query.get("sig"))):
         raise ValueError(url)
     return url

--- a/tests/crawlers/test_cases/fileditch.py
+++ b/tests/crawlers/test_cases/fileditch.py
@@ -54,4 +54,19 @@ TEST_CASES = [
         ],
         "count": 1,
     },
+    {
+        "url": "https://theditch.st/wtk8hvwb",
+        "description": "short URL (new signed URLs)",
+        "results": [
+            {
+                "url": "re:/beta22/1e34db7bc4a490dbdaa5/Oppenheimer.2023.2160p.PROPER.IMAX.HYBRID.UHD.REMUX.DV.HDR10_.TrueHD.7.1.Atmos.mkv?exp=",
+                "filename": "Oppenheimer.2023.2160p.PROPER.IMAX.HYBRID.UHD.REMUX.DV.HDR10_.TrueHD.7.1.Atmos.mkv",
+                "referer": "https://fileditchfiles.st/beta22/1e34db7bc4a490dbdaa5/Oppenheimer.2023.2160p.PROPER.IMAX.HYBRID.UHD.REMUX.DV.HDR10_.TrueHD.7.1.Atmos.mkv",
+                "album_id": None,
+                "uploaded_at": None,
+                "download_folder": "re:Loose Files (Fileditch)",
+            }
+        ],
+        "count": 1,
+    },
 ]


### PR DESCRIPTION
New uploads on some storage nodes sign download URLs with `exp`/`sig` query params instead of `md5`/`expires`. Both schemes are currently live, so accept either pair.

Fixes #2087

- add test case for the new scheme through a short URL (`theditch.st`)
- all 5 fileditch cases pass: `pytest --test-crawlers fileditch`