### PR TITLE
Fix substring matching when deciding what crawler to use

### DIFF
--- a/cyberdrop_dl/scrape_mapper.py
+++ b/cyberdrop_dl/scrape_mapper.py
@@ -419,7 +419,14 @@ def _best_match[T](current_map: dict[str, T], domain: str) -> T | None:
         return found
 
     try:
-        best_match = max((host for host in current_map if host in domain), key=len)
+        best_match = max(
+            (
+                host
+                for host in current_map
+                if domain == host or domain.startswith(f"{host}.") or domain.endswith(f".{host}")
+            ),
+            key=len,
+        )
     except (ValueError, TypeError):
         return None
     else:

--- a/tests/test_scrape_mapper.py
+++ b/tests/test_scrape_mapper.py
@@ -56,3 +56,10 @@ def test_skip_by_config() -> None:
     config.filters.skip_hosts.clear()
     config.filters.only_hosts = {"google.com"}
     assert scrape_mapper._skip_by_config(url, config) is True
+
+
+def test_best_match_does_not_use_substring_matches() -> None:
+    crawlers = {"anysex": "anysex", "sex.com": "sex.com"}
+
+    assert scrape_mapper._best_match(crawlers, "anysex.com") == "anysex"
+    assert scrape_mapper._best_match(crawlers, "www.sex.com") == "sex.com"


### PR DESCRIPTION
Fix substring matching when deciding what crawler to use.

Previously, trying to scrape `anysex.com` would match `sex.com`.