### PR TITLE
perf: delay heavy import

### DIFF
--- a/cyberdrop_dl/__init__.py
+++ b/cyberdrop_dl/__init__.py
@@ -1,25 +1,26 @@
-import importlib.metadata
-import re
+from __future__ import annotations
+
+TYPE_CHECKING = False
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 __dist_name__ = "cyberdrop-dl-patched"
-_distribution = importlib.metadata.distribution(__dist_name__)
-__version__ = _distribution.version
-__repo_url__ = next(
-    f.removeprefix(prefix) for f in _distribution.metadata.json["project_url"] if f.startswith(prefix := "Repository, ")
-)
+__version__ = "10.8.0"
+__repo_url__ = "https://github.com/Cyberdrop-DL/cyberdrop-dl"
 
 
-def _get_version(name: str) -> str | None:
-    try:
-        return importlib.metadata.version(name)
-    except importlib.metadata.PackageNotFoundError:
-        return None
+def dependencies() -> Generator[tuple[str, str | None]]:
+    import importlib.metadata
+    import re
 
+    for req in importlib.metadata.distribution(__dist_name__).requires or []:
+        m = re.match(r"^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?", req)
+        assert m is not None
+        pkg = m.group(0)
+        try:
+            version = importlib.metadata.version(pkg)
+        except importlib.metadata.PackageNotFoundError:
+            version = None
 
-def _parse_name(pep508_requirement: str) -> str:
-    m = re.match(r"^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?", pep508_requirement)
-    assert m is not None
-    return m.group(0)
-
-
-ALL_DEPENDENCIES = {pkg: _get_version(pkg) for req in (_distribution.requires or []) if (pkg := _parse_name(req))}
+        yield pkg, version

--- a/cyberdrop_dl/__init__.py
+++ b/cyberdrop_dl/__init__.py
@@ -1,17 +1,18 @@
 from __future__ import annotations
 
+import importlib.metadata
+
 TYPE_CHECKING = False
 
 if TYPE_CHECKING:
     from collections.abc import Generator
 
 __dist_name__ = "cyberdrop-dl-patched"
-__version__ = "10.8.0"
+__version__ = importlib.metadata.version(__dist_name__)
 __repo_url__ = "https://github.com/Cyberdrop-DL/cyberdrop-dl"
 
 
 def dependencies() -> Generator[tuple[str, str | None]]:
-    import importlib.metadata
     import re
 
     for req in importlib.metadata.distribution(__dist_name__).requires or []:

--- a/cyberdrop_dl/__main__.py
+++ b/cyberdrop_dl/__main__.py
@@ -33,19 +33,24 @@ def run_cdl(args: Sequence[str] | None = None) -> int:
     tracebacks.install_exception_hook()
 
     with setup_console_logging():
-        from pydantic import ValidationError
-
         from cyberdrop_dl.cli import app
         from cyberdrop_dl.exceptions import CDLConfigRuntimeErrorsGroup, DatabaseError
 
         try:
             app(parse_tokens(args))
-        except (ValidationError, DatabaseError) as exc:
+        except DatabaseError as exc:
             tb = tracebacks.from_exception(exc.with_traceback(None))
             app.console.print(_error_panel(tb))
         except CDLConfigRuntimeErrorsGroup as exc_group:
             tb = tracebacks.from_exception(exc_group)
             app.console.print(_error_panel(tb, title=exc_group.message or "Invalid Config"))
+        except ValueError as exc:
+            from pydantic_core import ValidationError
+
+            if not isinstance(exc, ValidationError):
+                raise
+            tb = tracebacks.from_exception(exc.with_traceback(None))
+            app.console.print(_error_panel(tb))
         else:
             return 0
 

--- a/cyberdrop_dl/aio.py
+++ b/cyberdrop_dl/aio.py
@@ -6,9 +6,7 @@ from __future__ import annotations
 import asyncio
 import builtins
 import contextlib
-import contextvars
 import dataclasses
-import shutil
 import sys
 from pathlib import Path
 from stat import S_ISREG
@@ -448,13 +446,18 @@ def to_thread[**P, R](fn: Callable[P, R]) -> Callable[P, Coroutine[None, None, R
     return async_run
 
 
+@to_thread
+def move(src: Path, dst: Path) -> None:
+    import shutil
+
+    shutil.move(src, dst)
+
+
 chmod = to_thread(Path.chmod)
-copy = to_thread(shutil.copy)
 exists = to_thread(Path.exists)
 is_dir = to_thread(Path.is_dir)
 is_file = to_thread(Path.is_file)
 mkdir = to_thread(Path.mkdir)
-move = to_thread(shutil.move)
 read_bytes = to_thread(Path.read_bytes)
 read_text = to_thread(Path.read_text)
 resolve = to_thread(Path.resolve)
@@ -568,6 +571,8 @@ async def backgroud_task(
     if period < 0.1:
         raise ValueError(f"{period = } is too low. Must be > 0.1")
 
+    import contextvars
+
     done: asyncio.Event = asyncio.Event()
 
     async def run_forever() -> None:
@@ -577,6 +582,8 @@ async def backgroud_task(
                 await asyncio.wait_for(done.wait(), period)
             except TimeoutError:
                 continue
+            else:
+                return
 
     task = asyncio.create_task(run_forever(), name=name, context=contextvars.copy_context())
     try:

--- a/cyberdrop_dl/commands/report.py
+++ b/cyberdrop_dl/commands/report.py
@@ -21,7 +21,7 @@ def _table(title: str | None, headers: Sequence[str], rows: Iterable[Row]) -> st
 
 
 def generate_report() -> str:
-    from cyberdrop_dl import ALL_DEPENDENCIES, __version__, ffmpeg
+    from cyberdrop_dl import __version__, dependencies, ffmpeg
     from cyberdrop_dl.__main__ import __file__ as entrypoint
     from cyberdrop_dl.config.appdata import AppData
     from cyberdrop_dl.utils import get_system_information
@@ -51,7 +51,7 @@ def generate_report() -> str:
             _table(
                 "Dependencies",
                 ["Package", "Version"],
-                _unpack(ALL_DEPENDENCIES.items()),
+                _unpack(dependencies()),
             ),
         ]
     )

--- a/cyberdrop_dl/config/__init__.py
+++ b/cyberdrop_dl/config/__init__.py
@@ -4,10 +4,12 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Any, Literal, final
 
-import yaml
 from cyclopts import App, Parameter
 from cyclopts.bind import normalize_tokens
-from pydantic import AfterValidator, BaseModel, Field, NonNegativeInt, PositiveInt
+from pydantic.fields import Field
+from pydantic.functional_validators import AfterValidator
+from pydantic.main import BaseModel
+from pydantic.types import NonNegativeInt, PositiveInt  # noqa: TC002
 
 from cyberdrop_dl.config.appdata import AppData
 from cyberdrop_dl.constants import DEFAULT_PARAMETER
@@ -129,6 +131,8 @@ class Config(ConfigModel, title="cyberdrop-dl config"):
         return self._sources[0] if self._sources else None
 
     def dump_yaml(self) -> str:
+        import yaml
+
         return yaml.safe_dump(self.model_dump(mode="json"), default_flow_style=False)
 
     def save_to(self, file: Path) -> None:
@@ -202,6 +206,8 @@ class Config(ConfigModel, title="cyberdrop-dl config"):
 
 
 def _load_yaml(file: Path) -> dict[str, Any]:
+    import yaml
+
     try:
         return yaml.safe_load(file.read_text()) or {}
     except yaml.YAMLError as e:

--- a/cyberdrop_dl/config/auth.py
+++ b/cyberdrop_dl/config/auth.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import importlib.util
 import logging
 from typing import TYPE_CHECKING, Any, override
 
@@ -14,7 +13,6 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
 
 logger = logging.getLogger(__name__)
-_HAS_APPRISE = importlib.util.find_spec("apprise") is not None
 
 
 def _censor(value: object) -> object:
@@ -61,7 +59,12 @@ class Notifications(CensoredModel):
     @override
     def model_post_init(self, context: Any, /) -> None:
         super().model_post_init(context)
-        if self.apprise and not _HAS_APPRISE:
+        if not self.apprise:
+            return
+
+        import importlib.util
+
+        if not importlib.util.find_spec("apprise"):
             logger.warning("Found apprise URLs for notifications but apprise is not installed. Ignoring")
             self.apprise = ()
 

--- a/cyberdrop_dl/exceptions.py
+++ b/cyberdrop_dl/exceptions.py
@@ -5,12 +5,11 @@ from http import HTTPStatus
 from pathlib import Path
 from typing import TYPE_CHECKING, Protocol, final
 
-import yarl
-
 if TYPE_CHECKING:
     import datetime
     from collections.abc import Sequence
 
+    import yarl
     from yaml import YAMLError
 
 
@@ -274,6 +273,8 @@ def create_error_msg(error: int | str) -> str:
 
 
 def get_origin(origin: HasParents | Path | yarl.URL | None = None) -> Path | yarl.URL | None:
+    import yarl
+
     if origin is None:
         return None
     if type(origin) is yarl.URL:

--- a/cyberdrop_dl/manager.py
+++ b/cyberdrop_dl/manager.py
@@ -8,7 +8,7 @@ import sys
 import time
 from typing import TYPE_CHECKING, Any, Self, final
 
-from cyberdrop_dl import ALL_DEPENDENCIES, __version__, aio, env, ffmpeg, stats
+from cyberdrop_dl import __version__, aio, dependencies, env, ffmpeg, stats
 from cyberdrop_dl.cache import cache_context
 from cyberdrop_dl.clients.downloads import DownloadClient
 from cyberdrop_dl.clients.http import HTTPClient
@@ -185,7 +185,7 @@ class Manager:
 def _log_dependencies() -> None:
     if not env.DEBUG_MODE:
         return
-    logger.debug({"dependencies": ALL_DEPENDENCIES})
+    logger.debug({"dependencies": dict(dependencies())})
 
 
 def _log_database(path: Path) -> None:

--- a/cyberdrop_dl/models/__init__.py
+++ b/cyberdrop_dl/models/__init__.py
@@ -1,19 +1,20 @@
 """Pydantic models"""
 
+from __future__ import annotations
+
 import logging
-import time
-import warnings
-from collections.abc import Generator, Iterable
-from typing import Any, ClassVar, Final, Self, TypedDict, final, get_args, get_origin, override
+from typing import TYPE_CHECKING, Any, ClassVar, Final, Self, TypedDict, final, get_args, get_origin, override
 
 from cyclopts import Parameter
-from cyclopts.annotations import resolve
 from pydantic import AnyUrl, BaseModel, Secret, SerializationInfo, TypeAdapter, model_serializer, model_validator
-from pydantic.fields import FieldInfo
+from pydantic.fields import FieldInfo  # noqa: TC002
 
 from cyberdrop_dl import env
 from cyberdrop_dl.constants import DEFAULT_PARAMETER
 from cyberdrop_dl.utils import fast_cache, operators
+
+if TYPE_CHECKING:
+    from collections.abc import Generator, Iterable
 
 logger = logging.getLogger(__name__)
 
@@ -42,6 +43,8 @@ class ConfigModel(DeferredModel, extra="forbid"):
         deprecated = self.model_fields_set.intersection(_deprecated_fields(self))
         if not deprecated:
             return
+
+        import time
 
         for field in deprecated:
             warn_id = type(self), field
@@ -241,6 +244,8 @@ class FieldMetadata:
 
     @classmethod
     def _resolve(cls, model: BaseModel) -> Generator[str]:
+        import warnings
+
         for name, field in type(model).model_fields.items():
             if cls._check(field):
                 yield name
@@ -259,6 +264,8 @@ class AdditiveArg(FieldMetadata):
     @override
     @classmethod
     def _check(cls, field: FieldInfo) -> bool:
+        from cyclopts.annotations import resolve
+
         if get_origin(field.annotation) in {set, list, tuple}:
             arg = resolve(get_args(field.annotation)[0])
             all_args = get_args(arg) or [arg]
@@ -269,6 +276,8 @@ class AdditiveArg(FieldMetadata):
 
 
 def _is_str(type_: object) -> bool:
+    from cyclopts.annotations import resolve
+
     type_ = resolve(type_)
     if type_ is str:
         return True

--- a/cyberdrop_dl/models/validators/__init__.py
+++ b/cyberdrop_dl/models/validators/__init__.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import datetime
-import re
 from typing import TYPE_CHECKING, Literal, SupportsIndex, SupportsInt, overload
 
 from pydantic import ByteSize, TypeAdapter
@@ -13,8 +12,6 @@ if TYPE_CHECKING:
     from cyberdrop_dl.url_objects import AbsoluteHttpURL
 
 
-_DATE_PATTERN_REGEX = r"(\d+)\s*(second|seconds|minute|minutes|hour|hours|day|days|week|weeks|month|months|year|years)"
-_DATE_PATTERN = re.compile(_DATE_PATTERN_REGEX, re.IGNORECASE)
 _BYTE_SIZE_ADAPTER = TypeAdapter(ByteSize)
 
 type _ConvertibleToInt = str | SupportsInt | SupportsIndex
@@ -42,8 +39,14 @@ def change_path_suffix(suffix: str) -> Callable[[Path], Path]:
 
 
 def _str_to_timedelta(input_date: str) -> datetime.timedelta:
+    import re
+
     time_str = input_date.casefold()
-    matches: list[str] = re.findall(_DATE_PATTERN, time_str)
+    matches: list[str] = re.findall(
+        r"(\d+)\s*(second|seconds|minute|minutes|hour|hours|day|days|week|weeks|month|months|year|years)",
+        time_str,
+        re.IGNORECASE,
+    )
     seen_units: set[str] = set()
     time_dict: dict[str, int] = {"days": 0}
 

--- a/cyberdrop_dl/models/validators/path.py
+++ b/cyberdrop_dl/models/validators/path.py
@@ -1,4 +1,9 @@
-from pathlib import Path
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def exists[T: Path](path: T) -> T:

--- a/cyberdrop_dl/utils/__init__.py
+++ b/cyberdrop_dl/utils/__init__.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
-import base64
 import contextlib
 import itertools
 import logging
-import platform
 import sys
 from typing import TYPE_CHECKING, Any, cast
 
@@ -67,6 +65,7 @@ class TextExtractor:
 
 
 def get_system_information() -> dict[str, Any]:
+    import platform
     import sqlite3
     import ssl
 
@@ -127,6 +126,8 @@ def truncated_preview(content: str, max_len: int = 100) -> str:
 
 
 def basic_auth(username: str, password: str) -> str:
+    import base64
+
     token = base64.b64encode(f"{username}:{password}".encode()).decode("ascii")
     return f"Basic {token}"
 

--- a/cyberdrop_dl/utils/_url.py
+++ b/cyberdrop_dl/utils/_url.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
-import re
 from typing import TYPE_CHECKING
 
-import yarl
-
-from cyberdrop_dl.url_objects import AbsoluteHttpURL, is_absolute_http_url
+from typing_extensions import TypeIs
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
+
+    import yarl
+
+    from cyberdrop_dl.url_objects import AbsoluteHttpURL
 
 
 def fix_query_params_encoding(link: str) -> str:
@@ -20,10 +21,14 @@ def fix_query_params_encoding(link: str) -> str:
 
 
 def fix_multi_slashes(url: str) -> str:
+    import re
+
     return re.sub(r"(^/|https?:/)/+", r"\1/", url, count=1)
 
 
 def str_to_url(url: str) -> yarl.URL:
+    import yarl
+
     if not url:
         raise ValueError("Empty URL", url)
 
@@ -40,7 +45,7 @@ def parse_http_url(
     """Parse a string into an absolute URL, handling relative URLs, encoding and optionally removes trailing slash (trimming)."""
 
     url = str_to_url(link) if isinstance(link, str) else link
-    if not is_absolute_http_url(url):
+    if not _is_absolute_http_url(url):
         if not relative_to:
             raise ValueError("Relative URL with no known origin", url)
         url = resolve_url(url, relative_to)
@@ -55,7 +60,7 @@ def resolve_url(url: yarl.URL, origin: AbsoluteHttpURL) -> AbsoluteHttpURL:
     url = origin.join(url) if not url.absolute else url
     if not url.scheme:
         url = url.with_scheme(origin.scheme if origin else "https")
-    if not is_absolute_http_url(url):
+    if not _is_absolute_http_url(url):
         raise ValueError(f"Unable to parse an absolute URL from {url}")
     return url
 
@@ -74,6 +79,8 @@ def remove_trailing_slash(url: AbsoluteHttpURL) -> AbsoluteHttpURL:
 
 
 def matches_any_host(url: yarl.URL, hosts: Iterable[str]) -> bool:
+    import yarl
+
     if not url.host:
         return False
 
@@ -85,3 +92,7 @@ def matches_any_host(url: yarl.URL, hosts: Iterable[str]) -> bool:
             return True
 
     return False
+
+
+def _is_absolute_http_url(url: yarl.URL) -> TypeIs[AbsoluteHttpURL]:
+    return url.absolute and url.scheme in {"http", "https"}


### PR DESCRIPTION
After this, the bulk of the import at startup is `cyberdrop_dl.config` (78%)

From that 78%, 28% is importing `cyclopts`, 35% importing `pydantic` and the rest is mostly just creating our custom types and models.

The other big chunk of the startup time is `importlib.metadata`. Just importing it takes 22% of the entire time. But I did not remove it (it's too convenient)

