### PR TITLE
fix: decode unicode escapes in page vars (bunkr)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pagination of some profiles stopping early (Twitter/x.com)
 - Pagination of some profiles never stopping (Twitter/x.com)
 - Some posts missing if a profile has 1k+ tweets (Twitter/x.com)
+- Downloads failing with 404 when the file name contains "&" or "'" (Bunkr)
 
 ## [10.8.0] - 2026-09-06
 

--- a/cyberdrop_dl/crawlers/bunkr.py
+++ b/cyberdrop_dl/crawlers/bunkr.py
@@ -328,6 +328,12 @@ def _extract_js_vars(soup: BeautifulSoup) -> dict[str, str]:
 
 
 def _fix_encoding(val: str) -> str:
+    # Double-quoted page vars are JSON strings, so decode every escape, not just `\/`
+    if val.startswith('"'):
+        try:
+            return json.loads(val)
+        except ValueError:
+            pass
     return val.replace(r"\/", "/")
 
 

--- a/tests/crawlers/test_bunkr.py
+++ b/tests/crawlers/test_bunkr.py
@@ -1,4 +1,5 @@
 import pytest
+from bs4 import BeautifulSoup
 
 from cyberdrop_dl.crawlers import bunkr
 from cyberdrop_dl.url_objects import AbsoluteHttpURL
@@ -130,3 +131,27 @@ def test_fix_tumb(url: str, expected: str | None) -> None:
     result = bunkr._fix_thumb(AbsoluteHttpURL(url))
     thumb = AbsoluteHttpURL(expected) if expected else None
     assert result == thumb
+
+
+@pytest.mark.parametrize(
+    ("js_value", "expected"),
+    [
+        (
+            r'"https:\/\/c4ta-b.cdn.cr\/storage\/media\/Tom-\u0026-Jerry-AbCd1234.mp4"',
+            "https://c4ta-b.cdn.cr/storage/media/Tom-&-Jerry-AbCd1234.mp4",
+        ),
+        (
+            r'"https:\/\/c3pz-b.cdn.cr\/storage\/media\/My-Friend\u0027s-Video-AbCd1234.mp4"',
+            "https://c3pz-b.cdn.cr/storage/media/My-Friend's-Video-AbCd1234.mp4",
+        ),
+        (
+            r'"https:\/\/c4ta-b.cdn.cr\/storage\/media\/plain-AbCd1234.mp4"',
+            "https://c4ta-b.cdn.cr/storage/media/plain-AbCd1234.mp4",
+        ),
+        (r"'https:\/\/x.cr\/a.mp4'", "https://x.cr/a.mp4"),
+        ("123", "123"),
+    ],
+)
+def test_extract_js_vars(js_value: str, expected: str) -> None:
+    soup = BeautifulSoup(f"<script>var jsCDN = {js_value};</script>", "html.parser")
+    assert bunkr._extract_js_vars(soup)["jsCDN"] == expected


### PR DESCRIPTION
I was running into an issue where Bunkr URLs were 404ing via this tool but if I tried them in a browser they worked just fine. I did some tracing of the issue with AI and was able to find it was some characters that weren't getting decoded causing it to hit the wrong URL. With this change double quoted values like `\u0026` now become `&` and `\u0027` becomes `'`.

Of note, this was a regression. #1181 fixed this for the old jsSlug path. The switch to the new API in #1925 (3b42cd4) brought back the `\/`-only decode.

I ended up with `json.loads` instead of the `encode().decode("unicode-escape")` approach from #1181 because it was garbling non-ASCII names.