### PR TITLE
fix: send a valid Origin header (yandex disk)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Downloads failing with 404 when the file name contains "&" or "'" (Bunkr)
 - Downloads of embeded videos and direct URLs (Imagepond)
 - Thumbnails downloads always failing with 404 (Cyberdrop)
+- Downloads failing with "DDoS-Guard" errors (Yandex Disk)
 
 ## [10.8.0] - 2026-09-06
 

--- a/cyberdrop_dl/crawlers/yandex_disk.py
+++ b/cyberdrop_dl/crawlers/yandex_disk.py
@@ -123,14 +123,7 @@ class YandexDiskCrawler(Crawler):
         if await self.check_complete_from_referer(scrape_item.url):
             return None
 
-        referer = str(file.url)
-        headers = _DEFAULT_HEADERS | {
-            "Content-Type": "text/plain",
-            "X-Requested-With": "XMLHttpRequest",
-            "Origin": str(scrape_item.url.host),
-            "Referer": referer,
-            "X-Retpath-Y": referer,
-        }
+        headers = _download_url_headers(scrape_item.url, file.url)
 
         api_url = _DOWNLOAD_API_ENTRYPOINT.with_host(scrape_item.url.host)
         with self._request_context():
@@ -158,6 +151,16 @@ class YandexDiskCrawler(Crawler):
         filename = link.query.get("filename") or file.name
         filename, ext = self.get_filename_and_ext(filename)
         await self.handle_file(file.url, scrape_item, filename, ext, debrid_link=link)
+
+
+def _download_url_headers(url: AbsoluteHttpURL, referer: AbsoluteHttpURL) -> dict[str, str]:
+    return _DEFAULT_HEADERS | {
+        "Content-Type": "text/plain",
+        "X-Requested-With": "XMLHttpRequest",
+        "Origin": str(url.origin()),
+        "Referer": str(referer),
+        "X-Retpath-Y": str(referer),
+    }
 
 
 def _get_item_info(soup: BeautifulSoup) -> dict[str, Any]:

--- a/tests/crawlers/test_yandex_disk.py
+++ b/tests/crawlers/test_yandex_disk.py
@@ -1,0 +1,19 @@
+import pytest
+
+from cyberdrop_dl.crawlers import yandex_disk
+from cyberdrop_dl.url_objects import AbsoluteHttpURL
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("https://disk.yandex.com/i/AbCdEf123", "https://disk.yandex.com"),
+        ("https://disk.yandex.com.tr/d/AbCdEf123/video.mp4", "https://disk.yandex.com.tr"),
+        ("https://disk.yandex.ru/i/AbCdEf123", "https://disk.yandex.ru"),
+    ],
+)
+def test_download_url_headers_origin(url: str, expected: str) -> None:
+    referer = AbsoluteHttpURL("https://yadi.sk/i/AbCdEf123")
+    headers = yandex_disk._download_url_headers(AbsoluteHttpURL(url), referer)
+    assert headers["Origin"] == expected
+    assert headers["Referer"] == headers["X-Retpath-Y"] == str(referer)


### PR DESCRIPTION
I was getting `DDoS-Guard` errors on Yandex but I didn't see any DDoS-Guard in a browser so I was suspicious something was off here. I had Claude look into it and it found that the actual failure was the follow-up `POST /public/api/download-url` call returning `403 {"error": true}` which `_request_context` then turns into `DDOSGuardError`, making it look like an anti-bot block when it isn’t.

The `Origin` header being sent was just `str(scrape_item.url.host)` (disk.yandex.com), with no scheme. It looks like Yandex just got stricter at some point.

Fix is `url.origin()` instead of `url.host`. I moved the header dict into a module-level `_download_url_headers` helper so it could actually be unit tested, some of the other crawlers use the same pattern.