### PR TITLE
test: fix stale ffmpeg assertions and EDITOR env leak

### DIFF
--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -39,7 +39,7 @@ async def test_probe_url_command() -> None:
         "ffprobe",
         "-hide_banner",
         "-loglevel",
-        "error",
+        "warning",
         "-show_streams",
         "-show_format",
         "-print_format",
@@ -67,11 +67,9 @@ async def test_probe_url_w_headers() -> None:
     assert args == [
         "-tls_verify",
         "1",
+        "-headers",
+        "Authorization: Bearer token\r\nUser-Agent: test\r\n",
         "https://example.com/stream.m3u8",
-        "-headers",
-        "Authorization: Bearer token",
-        "-headers",
-        "User-Agent: test",
     ]
 
 
@@ -108,11 +106,11 @@ async def test_probe_url_proxy_headers_no_verify() -> None:
     assert args == [
         "-tls_verify",
         "0",
-        "https://example.com/stream.m3u8",
         "-headers",
-        "X-Custom: value",
+        "X-Custom: value\r\n",
         "-http_proxy",
         "http://proxy:8080",
+        "https://example.com/stream.m3u8",
     ]
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -154,7 +154,8 @@ def test_parse_http(url: str, origin: str | None, expected: str, *, trim: bool) 
 
 class TestTextEditor:
     @pytest.mark.skipif(sys.platform != "win32", reason="Windows only test")
-    def test_win_default(self, tmp_cwd: Path) -> None:
+    def test_win_default(self, tmp_cwd: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("EDITOR", raising=False)
         cmd = text_editor._find_win_editor()
         assert cmd == text_editor._editor_cmd()
         assert cmd == ("C:\\Windows\\system32\\notepad.exe",)
@@ -170,14 +171,16 @@ class TestTextEditor:
         )
 
     @pytest.mark.skipif(sys.platform != "darwin", reason="MAC OS test only")
-    def test_mac_os_default(self) -> None:
+    def test_mac_os_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("EDITOR", raising=False)
         cmd = text_editor._editor_cmd()
         assert cmd
         assert cmd == ("open", "-t", "-n", "-W")
         assert type(cmd[0]) is text_editor.OSDefaultCMD
 
     @pytest.mark.skipif(sys.platform in ("darwin", "win32"), reason="Linux test only")
-    def test_unix_default(self) -> None:
+    def test_unix_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("EDITOR", raising=False)
         cmd = text_editor._find_unix_editor()
         assert cmd
         assert cmd == text_editor._editor_cmd()


### PR DESCRIPTION
I whenever I ran `uv run pytest` locally I was getting 4 failures that looked like local environment noise. I ignored them for a bit and eventually went to dig in on them.

Three of them (`tests/test_ffmpeg.py::test_probe_url_command`, `test_probe_url_w_headers`, `test_probe_url_proxy_headers_no_verify`) turned out to not be local at all. #2118 made some changes that did not got reflected in the tests. It stays hidden because `ci.yaml` runs `pytest --ignore=tests/test_ffmpeg.py`, so the main CI never touches this file.

The fourth one, `TestTextEditor::test_mac_os_default`, is a real environment leak: it asserts `_editor_cmd()` returns the macOS default without clearing `$EDITOR` first, so it fails for anyone who has `$EDITOR` set locally. Added `monkeypatch.delenv("EDITOR", raising=False)` to it and to the other two `TestTextEditor` tests that `call _editor_cmd()`, since they’d have the same problem.
