### PR TITLE
fix: warn about unclosed block comments in input file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Enable the `--force-original-path` option on retry commands
 - Ask the user if they want to use the original download path after choosing `retry failed downloads` (main menu)
+- Log a warning when a block comment in the input file is never closed and URLs after it are ignored
 
 ### Fixed
 

--- a/cyberdrop_dl/scrape_source.py
+++ b/cyberdrop_dl/scrape_source.py
@@ -96,6 +96,7 @@ async def _parse_input_file_groups(input_file: Path) -> AsyncGenerator[tuple[str
         return
 
     block_quote = False
+    ignored_urls = 0
     current_group_name = ""
     async with aio.open(input_file, encoding="utf8") as f:
         async for line in f:
@@ -106,9 +107,22 @@ async def _parse_input_file_groups(input_file: Path) -> AsyncGenerator[tuple[str
                 yield (current_group_name, list(_regex_links(line)))
                 continue
 
-            block_quote = not block_quote if line == "#\n" else block_quote
+            if line == "#\n":  # A block quote begins or ends here
+                block_quote = not block_quote
+                ignored_urls = 0
+
             if not block_quote:
                 yield ("", list(_regex_links(line)))
+            else:
+                ignored_urls += sum(1 for _ in _regex_links(line))
+
+    if block_quote and ignored_urls:
+        logger.warning(
+            "Block comment in %s was never closed: %s URL(s) after its opening '#' line were ignored. "
+            "Add a line with only '#' where the comment should end",
+            input_file,
+            ignored_urls,
+        )
 
 
 async def load_items_from_iterable(items: Iterable[AbsoluteHttpURL | Path]) -> AsyncGenerator[ScrapeItem]:

--- a/docs/reference/config/sorting.md
+++ b/docs/reference/config/sorting.md
@@ -176,6 +176,27 @@ sort:
     incrementer: " ({i})"
 ```
 
+# Comments
+
+Lines that start with `#` are ignored.
+
+A line containing only `#` starts a block comment. Everything up to the next line containing only `#` is ignored, URLs included:
+
+```text
+https://example.com/file1.jpg
+#
+https://example.com/file2.jpg
+https://example.com/file3.jpg
+#
+https://example.com/file4.jpg
+```
+
+Only `file1.jpg` and `file4.jpg` would be downloaded.
+
+If a block comment is never closed, every URL after it is ignored and a warning is logged.
+
+Block comments have no effect inside a group. There, a line with only `#` is just an ordinary comment.
+
 # Group URLs
 
 It is possible to treat a list of URLs as a group, allowing them to be downloaded to a single folder.

--- a/tests/test_scrape_source.py
+++ b/tests/test_scrape_source.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import pytest
+
+from cyberdrop_dl import scrape_source
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+async def _parse(file: Path) -> list[str]:
+    return [str(url) async for _, urls in scrape_source._parse_input_file_groups(file) for url in urls]
+
+
+@pytest.mark.parametrize(
+    ("lines", "expected_urls", "expected_warning"),
+    [
+        (
+            ["https://a.com/1", "#", "https://a.com/2", "#", "https://a.com/3"],
+            ["https://a.com/1", "https://a.com/3"],
+            None,
+        ),
+        (["# header", "#", "# more header", "https://a.com/1", "https://a.com/2"], [], "2 URL(s)"),
+        (["https://a.com/1", "#", "# just a comment"], ["https://a.com/1"], None),
+        (["# header", "https://a.com/1"], ["https://a.com/1"], None),
+    ],
+)
+async def test_unclosed_block_comment_warns(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    lines: list[str],
+    expected_urls: list[str],
+    expected_warning: str | None,
+) -> None:
+    file = tmp_path / "URLs.txt"
+    file.write_text("\n".join(lines) + "\n", encoding="utf8")
+    with caplog.at_level(logging.WARNING):
+        assert await _parse(file) == expected_urls
+
+    messages = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+    warnings = [msg for msg in messages if "never closed" in msg]
+    if expected_warning is None:
+        assert not warnings
+    else:
+        assert len(warnings) == 1
+        assert expected_warning in warnings[0]


### PR DESCRIPTION
I ran into this way back and just worked around it. Figured it would be nice to surface a warning to the user so they know about the behaviour.

When I was adding comments in my urls.txt to sort things for myself I was originally confused why links weren't working